### PR TITLE
Shrink War board to fit game area

### DIFF
--- a/index.css
+++ b/index.css
@@ -192,7 +192,30 @@ body {
 }
 
 .game-main {
-  gap: 2rem;
+  gap: 1.5rem;
+}
+
+.page-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.game-layout {
+  display: flex;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+  align-items: stretch;
+}
+
+.game-main .game-controls {
+  flex: 0 0 280px;
+  max-width: 320px;
+  align-self: flex-start;
+}
+
+.game-layout .game-area {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .back-link {
@@ -322,7 +345,7 @@ body {
 }
 
 #canvas {
-  width: min(900px, 100%);
+  width: min(640px, 100%);
   min-height: 320px;
   border-radius: 16px;
   border: none;
@@ -351,6 +374,15 @@ body {
     width: calc(100% - 2rem);
     margin: 1.5rem auto 2.5rem;
     padding: clamp(1.25rem, 4vw, 2.5rem);
+  }
+
+  .game-layout {
+    flex-direction: column;
+  }
+
+  .game-main .game-controls {
+    flex: 1 1 auto;
+    max-width: 100%;
   }
 
   .game-area {

--- a/war.html
+++ b/war.html
@@ -17,24 +17,28 @@
       </div>
     </header>
     <main class="main game-main">
-      <a href="index.html" class="back-link">&larr; Back to Home</a>
-      <section class="game-controls" aria-label="War settings">
-        <h2>War Table</h2>
-        <div class="control-row">
-          <label for="Players">Number of Players</label>
-          <input type="number" min="2" max="4" step="1" id="Players" value="2" />
+      <div class="page-actions">
+        <a href="index.html" class="back-link">&larr; Back to Home</a>
+      </div>
+      <div class="game-layout">
+        <section class="game-controls" aria-label="War settings">
+          <h2>War Table</h2>
+          <div class="control-row">
+            <label for="Players">Number of Players</label>
+            <input type="number" min="2" max="4" step="1" id="Players" value="2" />
+          </div>
+          <div class="control-actions">
+            <button class="action-button" type="button" onclick="reset();">Reset</button>
+            <button class="action-button primary" type="button" onclick="flipAll();">Flip Cards</button>
+          </div>
+          <div class="status-row">
+            <label for="winner">Winning Player</label>
+            <input id="winner" value="0" readonly class="status-display" />
+          </div>
+        </section>
+        <div class="game-area">
+          <canvas id="canvas"></canvas>
         </div>
-        <div class="control-actions">
-          <button class="action-button" type="button" onclick="reset();">Reset</button>
-          <button class="action-button primary" type="button" onclick="flipAll();">Flip Cards</button>
-        </div>
-        <div class="status-row">
-          <label for="winner">Winning Player</label>
-          <input id="winner" value="0" readonly class="status-display" />
-        </div>
-      </section>
-      <div class="game-area">
-        <canvas id="canvas"></canvas>
       </div>
     </main>
     <script src="war.js"></script>

--- a/war.js
+++ b/war.js
@@ -109,8 +109,8 @@ const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 const dpr = window.devicePixelRatio || 1;
-const baseCanvasWidth = 800;
-const baseCanvasHeight = 550;
+const baseCanvasWidth = 640;
+const baseCanvasHeight = 440;
 canvas.style.width = baseCanvasWidth + 'px';
 canvas.style.height = baseCanvasHeight + 'px';
 canvas.width = baseCanvasWidth * dpr;


### PR DESCRIPTION
## Summary
- reduce the War canvas dimensions so the green play field fits comfortably inside the blue backdrop
- tighten the CSS width cap for the canvas to keep it within the padded game area

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ddbfdd0070832b814614c04d8415f5