### PR TITLE
Improve mobile navigation and layout

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Blackjack</title>
     <link rel="stylesheet" href="index.css" />
   </head>
@@ -9,7 +10,13 @@
     <header class="header">
       <div class="header-inner">
         <h1 class="title">Betting War</h1>
-        <nav class="menu-bar" aria-label="Main navigation">
+        <button class="menu-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="visually-hidden">Toggle navigation</span>
+          <span class="menu-toggle-bar" aria-hidden="true"></span>
+          <span class="menu-toggle-bar" aria-hidden="true"></span>
+          <span class="menu-toggle-bar" aria-hidden="true"></span>
+        </button>
+        <nav id="primary-navigation" class="menu-bar" aria-label="Main navigation">
           <a href="index.html" class="menu-button">Home</a>
           <a href="war.html" class="menu-button">War</a>
           <a href="blackjack.html" class="menu-button selected-button">Blackjack</a>
@@ -58,6 +65,7 @@
         </section>
       </div>
     </main>
+    <script src="nav.js"></script>
     <script src="blackjack.js"></script>
   </body>
 </html>

--- a/freemode.html
+++ b/freemode.html
@@ -2,14 +2,21 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>War</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Free Mode</title>
     <link rel="stylesheet" href="index.css" />
   </head>
   <body>
     <header class="header">
       <div class="header-inner">
         <h1 class="title">Betting War</h1>
-        <nav class="menu-bar" aria-label="Main navigation">
+        <button class="menu-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="visually-hidden">Toggle navigation</span>
+          <span class="menu-toggle-bar" aria-hidden="true"></span>
+          <span class="menu-toggle-bar" aria-hidden="true"></span>
+          <span class="menu-toggle-bar" aria-hidden="true"></span>
+        </button>
+        <nav id="primary-navigation" class="menu-bar" aria-label="Main navigation">
           <a href="index.html" class="menu-button">Home</a>
           <a href="war.html" class="menu-button">War</a>
           <a href="blackjack.html" class="menu-button">Blackjack</a>
@@ -27,6 +34,7 @@
         <canvas id="canvas"></canvas>
       </div>
     </main>
+    <script src="nav.js"></script>
     <script src="war.js"></script>
   </body>
 </html>

--- a/index.css
+++ b/index.css
@@ -40,6 +40,58 @@ body {
   gap: 1.5rem;
 }
 
+.menu-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(15, 23, 42, 0.25);
+  cursor: pointer;
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.menu-toggle:hover,
+.menu-toggle[aria-expanded="true"] {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: transparent;
+}
+
+.menu-toggle-bar {
+  width: 24px;
+  height: 2px;
+  background: #f8fafc;
+  border-radius: 999px;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+  transform-origin: center;
+}
+
+.menu-toggle[aria-expanded="true"] .menu-toggle-bar:nth-child(2) {
+  transform: translateY(4px) rotate(45deg);
+}
+
+.menu-toggle[aria-expanded="true"] .menu-toggle-bar:nth-child(3) {
+  opacity: 0;
+}
+
+.menu-toggle[aria-expanded="true"] .menu-toggle-bar:nth-child(4) {
+  transform: translateY(-4px) rotate(-45deg);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 .title {
   margin: 0;
   font-size: clamp(2rem, 4vw, 2.75rem);
@@ -54,6 +106,7 @@ body {
   gap: 0.75rem;
   flex-wrap: wrap;
   justify-content: flex-end;
+  transition: max-height 0.25s ease, opacity 0.2s ease;
 }
 
 .menu-button {
@@ -102,7 +155,8 @@ body {
   text-align: center;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+  padding: 0 clamp(0.25rem, 4vw, 1rem);
 }
 
 .hero h2 {
@@ -113,8 +167,8 @@ body {
 
 .hero p {
   margin: 0;
-  font-size: 1.05rem;
-  line-height: 1.7;
+  font-size: clamp(1rem, 2.5vw, 1.05rem);
+  line-height: 1.65;
   color: #334155;
 }
 
@@ -424,12 +478,40 @@ textarea.status-display {
 
   .header-inner {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
+    gap: 0.75rem;
   }
 
-  .menu-bar {
+  .js-enabled .menu-toggle {
+    display: inline-flex;
+    align-self: flex-end;
+  }
+
+  .js-enabled .menu-bar.menu-collapsible {
+    position: relative;
+    flex-direction: column;
+    align-items: stretch;
     width: 100%;
-    justify-content: flex-start;
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+    background: rgba(15, 23, 42, 0.88);
+    border-radius: 16px;
+    padding: 0;
+    box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.75);
+  }
+
+  .js-enabled .menu-bar.menu-collapsible.menu-open {
+    padding: 0.75rem;
+    max-height: 500px;
+    opacity: 1;
+    gap: 0.6rem;
+  }
+
+  .js-enabled .menu-bar.menu-collapsible .menu-button {
+    width: 100%;
+    justify-content: center;
+    padding: 0.75rem 1rem;
   }
 
   .main {
@@ -453,11 +535,6 @@ textarea.status-display {
 }
 
 @media (max-width: 480px) {
-  .menu-button {
-    width: 100%;
-    justify-content: center;
-  }
-
   .control-row {
     flex-direction: column;
     align-items: flex-start;
@@ -473,6 +550,24 @@ textarea.status-display {
 
   .action-button {
     flex: 1 1 auto;
+    width: 100%;
+  }
+
+  .hero {
+    text-align: left;
+    gap: 1.25rem;
+  }
+
+  .hero h2 {
+    font-size: clamp(1.8rem, 8vw, 2.2rem);
+  }
+
+  .cta-group {
+    justify-content: flex-start;
+  }
+
+  .primary-link,
+  .secondary-link {
     width: 100%;
   }
 }

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Betting War</title>
     <link rel="stylesheet" href="index.css" />
   </head>
@@ -9,7 +10,13 @@
     <header class="header">
       <div class="header-inner">
         <h1 class="title">Betting War</h1>
-        <nav class="menu-bar" aria-label="Main navigation">
+        <button class="menu-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="visually-hidden">Toggle navigation</span>
+          <span class="menu-toggle-bar" aria-hidden="true"></span>
+          <span class="menu-toggle-bar" aria-hidden="true"></span>
+          <span class="menu-toggle-bar" aria-hidden="true"></span>
+        </button>
+        <nav id="primary-navigation" class="menu-bar" aria-label="Main navigation">
           <a href="index.html" class="menu-button selected-button">Home</a>
           <a href="war.html" class="menu-button">War</a>
           <a href="blackjack.html" class="menu-button">Blackjack</a>
@@ -46,5 +53,6 @@
         </article>
       </section>
     </main>
+    <script src="nav.js"></script>
   </body>
 </html>

--- a/nav.js
+++ b/nav.js
@@ -1,0 +1,48 @@
+(function () {
+  document.documentElement.classList.add('js-enabled');
+
+  const onReady = () => {
+    const menuToggle = document.querySelector('.menu-toggle');
+    const menu = document.querySelector('#primary-navigation');
+
+    if (!menuToggle || !menu) {
+      return;
+    }
+
+    menu.classList.add('menu-collapsible');
+
+    const closeMenu = () => {
+      menuToggle.setAttribute('aria-expanded', 'false');
+      menu.classList.remove('menu-open');
+    };
+
+    const toggleMenu = () => {
+      const isOpen = menuToggle.getAttribute('aria-expanded') === 'true';
+      menuToggle.setAttribute('aria-expanded', String(!isOpen));
+      menu.classList.toggle('menu-open', !isOpen);
+    };
+
+    menuToggle.addEventListener('click', toggleMenu);
+
+    menu.addEventListener('click', (event) => {
+      if (event.target.classList.contains('menu-button')) {
+        closeMenu();
+      }
+    });
+
+    const handleResize = () => {
+      if (window.matchMedia('(min-width: 769px)').matches) {
+        closeMenu();
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', onReady);
+  } else {
+    onReady();
+  }
+})();

--- a/war.html
+++ b/war.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>War</title>
     <link rel="stylesheet" href="index.css" />
   </head>
@@ -9,7 +10,13 @@
     <header class="header">
       <div class="header-inner">
         <h1 class="title">Betting War</h1>
-        <nav class="menu-bar" aria-label="Main navigation">
+        <button class="menu-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="visually-hidden">Toggle navigation</span>
+          <span class="menu-toggle-bar" aria-hidden="true"></span>
+          <span class="menu-toggle-bar" aria-hidden="true"></span>
+          <span class="menu-toggle-bar" aria-hidden="true"></span>
+        </button>
+        <nav id="primary-navigation" class="menu-bar" aria-label="Main navigation">
           <a href="index.html" class="menu-button">Home</a>
           <a href="war.html" class="menu-button selected-button">War</a>
           <a href="blackjack.html" class="menu-button">Blackjack</a>
@@ -42,6 +49,7 @@
         </div>
       </div>
     </main>
+    <script src="nav.js"></script>
     <script src="war.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable mobile navigation toggle and viewport meta tags across all pages
- refine mobile spacing for the hero section and call-to-action buttons
- create a shared nav.js helper to manage collapsible menus when JavaScript is available

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df0a4f6a78832bb2d21a9b44ca6491